### PR TITLE
bugfix/PP-13614: JTL Order Confirmation Issue

### DIFF
--- a/jtl_payrexx/Bootstrap.php
+++ b/jtl_payrexx/Bootstrap.php
@@ -40,33 +40,6 @@ class Bootstrap extends Bootstrapper
         parent::boot($dispatcher);
         if (Shop::isFrontend()) {
             // Hooks
-            $dispatcher->listen(
-                'shop.hook.' . \HOOK_MAIL_PRERENDER,
-                function ($args) {
-                    if (isset($args['mail'])) {
-                        try {
-                            $email = $args['mail'];
-                            $emailData = $email->getData();
-
-                            // Check if order data and payment method exist
-                            if (isset($emailData->tbestellung) && $emailData->tbestellung->kZahlungsart) {
-                                $paymentMethodEntity = new Zahlungsart((int)$emailData->tbestellung->kZahlungsart);
-                                $paymentProvider = $paymentMethodEntity->cAnbieter ?? '';
-
-                                if ($paymentProvider === 'Payrexx' &&
-                                    $email->getTemplate()->getId() === \MAILTEMPLATE_BESTELLBESTAETIGUNG &&
-                                    (int) $emailData->tbestellung->cStatus !== (int) \BESTELLUNG_STATUS_BEZAHLT
-                                ) {
-                                    // $email->setToMail(''); // Set an empty recipient to stop sending
-                                }
-                            }
-                        } catch(\Exception $e) {
-                            // nothing
-                        }
-                    }
-                },
-                10
-            );
         } else {
             $dispatcher->listen('backend.notification', [$this, 'checkPayments']);
         }

--- a/jtl_payrexx/Bootstrap.php
+++ b/jtl_payrexx/Bootstrap.php
@@ -57,7 +57,7 @@ class Bootstrap extends Bootstrapper
                                     $email->getTemplate()->getId() === \MAILTEMPLATE_BESTELLBESTAETIGUNG &&
                                     (int) $emailData->tbestellung->cStatus !== (int) \BESTELLUNG_STATUS_BEZAHLT
                                 ) {
-                                    $email->setToMail(''); // Set an empty recipient to stop sending
+                                    // $email->setToMail(''); // Set an empty recipient to stop sending
                                 }
                             }
                         } catch(\Exception $e) {

--- a/jtl_payrexx/Migrations/Migration20241206094532.php
+++ b/jtl_payrexx/Migrations/Migration20241206094532.php
@@ -10,26 +10,16 @@ class Migration20241206094532 extends Migration implements IMigration
     public function up()
     {
         $this->execute(
-            "ALTER TABLE `plugin_jtl_payments` 
+            "ALTER TABLE `plugin_jtl_payrexx_payments` 
              ADD `order_hash` VARCHAR(100) NULL AFTER `gateway_id`;"
-        );
-
-        $this->execute(
-            "ALTER TABLE `plugin_jtl_payments` 
-             CHANGE `order_id` `order_id` INT NULL;"
         );
     }
 
     public function down()
     {
         $this->execute(
-            "ALTER TABLE `plugin_jtl_payments` 
+            "ALTER TABLE `plugin_jtl_payrexx_payments` 
              DROP COLUMN `order_hash`;"
-        );
-
-        $this->execute(
-            "ALTER TABLE `plugin_jtl_payments` 
-             CHANGE `order_id` `order_id` INT NOT NULL;"
         );
     }
 }

--- a/jtl_payrexx/Migrations/Migration20241206094532.php
+++ b/jtl_payrexx/Migrations/Migration20241206094532.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Plugin\jtl_payrexx\Migrations;
+
+use JTL\Plugin\Migration;
+use JTL\Update\IMigration;
+
+class Migration20241206094532 extends Migration implements IMigration
+{
+    public function up()
+    {
+        $this->execute(
+            "ALTER TABLE `plugin_jtl_payments` 
+             ADD `order_no` VARCHAR(25) NULL AFTER `gateway_id`;"
+        );
+
+        $this->execute(
+            "ALTER TABLE `plugin_jtl_payments` 
+             CHANGE `order_id` `order_id` INT NULL;"
+        );
+    }
+
+    public function down()
+    {
+        $this->execute(
+            "ALTER TABLE `plugin_jtl_payments` 
+             DROP COLUMN `order_no`;"
+        );
+
+        $this->execute(
+            "ALTER TABLE `plugin_jtl_payments` 
+             CHANGE `order_id` `order_id` INT NOT NULL;"
+        );
+    }
+}

--- a/jtl_payrexx/Migrations/Migration20241206094532.php
+++ b/jtl_payrexx/Migrations/Migration20241206094532.php
@@ -11,7 +11,7 @@ class Migration20241206094532 extends Migration implements IMigration
     {
         $this->execute(
             "ALTER TABLE `plugin_jtl_payments` 
-             ADD `order_no` VARCHAR(25) NULL AFTER `gateway_id`;"
+             ADD `order_hash` VARCHAR(100) NULL AFTER `gateway_id`;"
         );
 
         $this->execute(
@@ -24,7 +24,7 @@ class Migration20241206094532 extends Migration implements IMigration
     {
         $this->execute(
             "ALTER TABLE `plugin_jtl_payments` 
-             DROP COLUMN `order_no`;"
+             DROP COLUMN `order_hash`;"
         );
 
         $this->execute(

--- a/jtl_payrexx/info.xml
+++ b/jtl_payrexx/info.xml
@@ -7,7 +7,7 @@
     <PluginID>jtl_payrexx</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.0.0</ShopVersion>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <CreateDate>2024-04-15</CreateDate>
     <Install>
         <Adminmenu>

--- a/jtl_payrexx/paymentmethod/Base.php
+++ b/jtl_payrexx/paymentmethod/Base.php
@@ -114,6 +114,7 @@ class Base extends Method
      */
     public function preparePaymentProcess(Bestellung $order): void
     {
+        parent::preparePaymentProcess($order);
         if (isset($_SESSION['payrexxOrder'])) {
             $this->payrexxApiService->deletePayrexxGateway(
                 (int) $_SESSION['payrexxOrder']['gatewayId']

--- a/jtl_payrexx/src/Service/OrderService.php
+++ b/jtl_payrexx/src/Service/OrderService.php
@@ -17,9 +17,9 @@ class OrderService
      *
      * @param int|null $orderId
      * @param int $gatewayId
-     * @param string $orderNumber
+     * @param string $orderHash
      */
-    public function setPaymentGatewayId(?int $orderId, int $gatewayId, ?string $orderNumber): void
+    public function setPaymentGatewayId(?int $orderId, int $gatewayId, ?string $orderHash): void
     {
         $payrexxPayment = new stdClass();
         $payrexxPayment->gateway_id = $gatewayId;
@@ -28,7 +28,7 @@ class OrderService
             $payrexxPayment->order_id = (int) $orderId;
         }
         if ($orderNumber) {
-            $payrexxPayment->order_no = $orderNumber;
+            $payrexxPayment->order_hash = $orderHash;
         }
 
         Shop::Container()->getDB()->insert('plugin_jtl_payrexx_payments', $payrexxPayment);
@@ -46,7 +46,7 @@ class OrderService
         $info = Shop::Container()->getDB()->queryPrepared(
             'SELECT `gateway_id`, `order_id`
                 FROM `plugin_jtl_payrexx_payments`
-                WHERE (`order_id`  = :shopOrderId OR `order_no` = :shopOrderId) AND `gateway_id` = :gatewayId',
+                WHERE (`order_id`  = :shopOrderId OR `order_hash` = :shopOrderId) AND `gateway_id` = :gatewayId',
             [
                 ':shopOrderId' => $orderId,
                 ':gatewayId' => $gatewayId
@@ -237,7 +237,7 @@ class OrderService
         $result = Shop::Container()->getDB()->queryPrepared(
             'SELECT `gateway_id`, `order_id`
                 FROM `plugin_jtl_payrexx_payments`
-                WHERE (`order_id`  = :shopOrderId OR `order_no` = :shopOrderId)',
+                WHERE (`order_id`  = :shopOrderId OR `order_hash` = :shopOrderId)',
             [
                 ':shopOrderId' => $orderId,
             ],
@@ -254,7 +254,7 @@ class OrderService
         $result = Shop::Container()->getDB()->queryPrepared(
             'SELECT `kBestellung`
                 FROM `tbestellung`
-                WHERE (`kBestellung`  = :shopOrderId OR `cBestellNr` = :shopOrderId)',
+                WHERE `kBestellung`  = :shopOrderId',
             [
                 ':shopOrderId' => $orderId,
             ],

--- a/jtl_payrexx/src/Service/OrderService.php
+++ b/jtl_payrexx/src/Service/OrderService.php
@@ -27,7 +27,7 @@ class OrderService
         if ($orderId) {
             $payrexxPayment->order_id = (int) $orderId;
         }
-        if ($orderNumber) {
+        if ($orderHash) {
             $payrexxPayment->order_hash = $orderHash;
         }
 
@@ -46,7 +46,7 @@ class OrderService
         $info = Shop::Container()->getDB()->queryPrepared(
             'SELECT `gateway_id`, `order_id`
                 FROM `plugin_jtl_payrexx_payments`
-                WHERE (`order_id`  = :shopOrderId OR `order_hash` = :shopOrderId) AND `gateway_id` = :gatewayId',
+                WHERE (`order_id` = :shopOrderId OR `order_hash` = :shopOrderId) AND `gateway_id` = :gatewayId',
             [
                 ':shopOrderId' => $orderId,
                 ':gatewayId' => $gatewayId
@@ -228,38 +228,23 @@ class OrderService
         $paymentMethod->sendMail($order->kBestellung, \MAILTEMPLATE_BESTELLBESTAETIGUNG);
     }
 
-
     /**
-     * Get 
+     * Get order info by order Id.
+     * 
+     * @param string $referenceId
+     * @return object
      */
-    public function getOrderInfoByOrderId($orderId)
+    public function getOrderInfoByReference($referenceId)
     {
         $result = Shop::Container()->getDB()->queryPrepared(
             'SELECT `gateway_id`, `order_id`
                 FROM `plugin_jtl_payrexx_payments`
                 WHERE (`order_id`  = :shopOrderId OR `order_hash` = :shopOrderId)',
             [
-                ':shopOrderId' => $orderId,
+                ':shopOrderId' => $referenceId,
             ],
             ReturnType::SINGLE_OBJECT
         );
         return $result;
-    }
-
-    /**
-     * @param 
-     */
-    public function getShopOrderId($orderId)
-    {
-        $result = Shop::Container()->getDB()->queryPrepared(
-            'SELECT `kBestellung`
-                FROM `tbestellung`
-                WHERE `kBestellung`  = :shopOrderId',
-            [
-                ':shopOrderId' => $orderId,
-            ],
-            ReturnType::SINGLE_OBJECT
-        );
-        return (int) $result->kBestellung;
     }
 }

--- a/jtl_payrexx/src/Service/OrderService.php
+++ b/jtl_payrexx/src/Service/OrderService.php
@@ -225,7 +225,6 @@ class OrderService
         $incomingPayment->cHinweis = $uuid;
         $paymentMethod->addIncomingPayment($order, $incomingPayment);
         $paymentMethod->sendConfirmationMail($order);
-        $paymentMethod->sendMail($order->kBestellung, \MAILTEMPLATE_BESTELLBESTAETIGUNG);
     }
 
     /**

--- a/jtl_payrexx/src/Service/PayrexxApiService.php
+++ b/jtl_payrexx/src/Service/PayrexxApiService.php
@@ -164,6 +164,8 @@ class PayrexxApiService
     }
 
     /**
+     * Get payrexx gateway
+     *
      * @param integer $gatewayId
      * @return \Payrexx\Models\Request\Gateway|Exception
      */
@@ -173,10 +175,9 @@ class PayrexxApiService
         $gateway = new Gateway();
         $gateway->setId($gatewayId);
         try {
-            $payrexxGateway = $payrexx->getOne($gateway);
-            return $payrexxGateway;
+            return $payrexx->getOne($gateway);
         } catch (PayrexxException $e) {
-            throw new Exception('No gateway found by ID: ' . $gatewayId);
+            return null;
         }
     }
 
@@ -194,5 +195,33 @@ class PayrexxApiService
         } catch (PayrexxException $e) {
             return false;
         }
+    }
+
+    /**
+     * get the Payrexx Transaction
+     *
+     * @param int $gatewayId
+     * @return \Payrexx\Models\Response\Transaction|null
+     */
+    public function getTransactionByGatewayId(int $gatewayId)
+    {
+        if (!$gateway = $this->getPayrexxGateway($gatewayId)) {
+            return null;
+        }
+        if (!in_array($gateway->getStatus(), [Transaction::CONFIRMED, Transaction::WAITING])) {
+            return null;
+        }
+
+        $invoices = $gateway->getInvoices();
+
+        if (!$invoices || !$invoice = end($invoices)) {
+            return null;
+        }
+
+        if (!$transactions = $invoice['transactions']) {
+            return null;
+        }
+
+        return $this->getPayrexxTransaction(end($transactions)['id']);
     }
 }

--- a/jtl_payrexx/src/Service/PayrexxApiService.php
+++ b/jtl_payrexx/src/Service/PayrexxApiService.php
@@ -208,7 +208,13 @@ class PayrexxApiService
         if (!$gateway = $this->getPayrexxGateway($gatewayId)) {
             return null;
         }
-        if (!in_array($gateway->getStatus(), [Transaction::CONFIRMED, Transaction::WAITING])) {
+        if (!in_array(
+            $gateway->getStatus(),
+            [
+                ResponseTransaction::CONFIRMED,
+                ResponseTransaction::WAITING
+            ]
+        )) {
             return null;
         }
 

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -51,7 +51,7 @@ class Dispatcher
             if (empty($orderId)) {
                 $this->sendResponse('Webhook data incomplete');
             }
-            $verify = $this->orderService->getOrderGatewayId((int) $orderId, (int) $gatewayId);
+            $verify = $this->orderService->getOrderGatewayId($orderId, (int) $gatewayId);
             if (!$verify) {
                 $this->sendResponse('Verification failed');
             }
@@ -69,14 +69,17 @@ class Dispatcher
             if ($transaction->getStatus() !== $this->data['transaction']['status']) {
                 $this->sendResponse('Fraudulent transaction status');
             }
+            $orderId = $this->orderService->getShopOrderId($orderId);
             $order = new Bestellung((int)$orderId);
-            $this->orderService->handleTransactionStatus(
-                $order,
-                $transaction->getStatus(),
-                $transaction->getUuid(),
-                $transaction->getInvoice()['currencyAlpha3'],
-                (int) $transaction->getInvoice()['totalAmount']
-            );
+            if ($order) {
+                $this->orderService->handleTransactionStatus(
+                    $order,
+                    $transaction->getStatus(),
+                    $transaction->getUuid(),
+                    $transaction->getInvoice()['currencyAlpha3'],
+                    (int) $transaction->getInvoice()['totalAmount']
+                );
+            }
             $this->sendResponse('Webhook processed successfully!');
         } catch (Exception $e) {
             $this->sendResponse('Error: ' . json_encode($e->getMessage()));

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -69,8 +69,12 @@ class Dispatcher
             if ($transaction->getStatus() !== $this->data['transaction']['status']) {
                 $this->sendResponse('Fraudulent transaction status');
             }
-            $orderId = $this->orderService->getShopOrderId($orderId);
-            $order = new Bestellung((int)$orderId);
+            if (!$order = new Bestellung((int) $orderId)) {
+                $result = $this->orderService->getOrderInfoByOrderId($orderId);
+                if ($result) {
+                    $order = new Bestellung((int)$result->order_id);
+                }
+            }
             if ($order) {
                 $this->orderService->handleTransactionStatus(
                     $order,

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -45,13 +45,14 @@ class Dispatcher
             if (empty($this->data)) {
                 $this->sendResponse('Webhook data incomplete');
             }
-            $orderId = $this->data['transaction']['invoice']['referenceId'] ?? '';
+            // reference id refers order id or order hash
+            $referenceId = $this->data['transaction']['invoice']['referenceId'] ?? '';
             $gatewayId = $this->data['transaction']['invoice']['paymentRequestId'] ?? '';
 
-            if (empty($orderId)) {
+            if (empty($referenceId)) {
                 $this->sendResponse('Webhook data incomplete');
             }
-            $verify = $this->orderService->getOrderGatewayId($orderId, (int) $gatewayId);
+            $verify = $this->orderService->getOrderGatewayId($referenceId, (int) $gatewayId);
             if (!$verify) {
                 $this->sendResponse('Verification failed');
             }
@@ -69,13 +70,14 @@ class Dispatcher
             if ($transaction->getStatus() !== $this->data['transaction']['status']) {
                 $this->sendResponse('Fraudulent transaction status');
             }
-            if (!$order = new Bestellung((int) $orderId)) {
-                $result = $this->orderService->getOrderInfoByOrderId($orderId);
+            $order = new Bestellung((int) $referenceId);
+            if (!$order->kBestellung) {
+                $result = $this->orderService->getOrderInfoByReference($referenceId);
                 if ($result) {
                     $order = new Bestellung((int)$result->order_id);
                 }
             }
-            if ($order) {
+            if ($order->kBestellung) {
                 $this->orderService->handleTransactionStatus(
                     $order,
                     $transaction->getStatus(),


### PR DESCRIPTION
Implemented a new feature to support after successful payment create order on JTL shop5


**Existing functionality:**

We have only supported, creating the order and then redirecting the payment gateway to pay.

In this case, the customer wants to stop the order confirmation email, so I have removed the email (setToMail()) using a hook.

It is working customer expected but the log is occurring as the customer mentioned.


**New solution:**

1. Removed the hook to remove the email.
2. Implemented the new feature, According to the JTL shop settings (Payment before order completion : yes)
3. If the option is enabled the customer first paid then the order will be created.
4. The customer should be paid and redirected to Shop then only the order will be created. 


**Additionally:**
1. Added language redirection for the Payment gateway with support  'it', 'fr', 'nl', 'pt', 'tr' like as the Woocommerce.
2. Implemented the delete gateway functionality.
