### PR TITLE
bugfix/PP-13894: Plugin JTL: Issues With Payment Before Order Creation

### DIFF
--- a/jtl_payrexx/info.xml
+++ b/jtl_payrexx/info.xml
@@ -7,7 +7,7 @@
     <PluginID>jtl_payrexx</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.0.0</ShopVersion>
-    <Version>1.0.14</Version>
+    <Version>1.0.15</Version>
     <CreateDate>2024-04-15</CreateDate>
     <Install>
         <Adminmenu>

--- a/jtl_payrexx/paymentmethod/Base.php
+++ b/jtl_payrexx/paymentmethod/Base.php
@@ -125,7 +125,7 @@ class Base extends Method
         }
         $payrexxApiService = new PayrexxApiService();
         $orderHash = $this->generateHash($order);
-        $successUrl = $this->getNotificationURL($orderHash);
+        $successUrl = $this->getReturnURL($order);
         $cancelUrl =  $this->getNotificationURL($orderHash) . '&cancelled';
         $basketItems = BasketUtil::getBasketDetails($order);
         $basketAmount = BasketUtil::getBasketAmount($basketItems);
@@ -162,8 +162,6 @@ class Base extends Method
                 $successUrl .= '&orderNo=' . $orderNumber;
                 $order->cBestellNr = $orderNumber;
             }
-        } else {
-           $successUrl = $this->getReturnURL($order);
         }
 
         $gateway = $payrexxApiService->createPayrexxGateway(

--- a/jtl_payrexx/paymentmethod/Base.php
+++ b/jtl_payrexx/paymentmethod/Base.php
@@ -129,7 +129,7 @@ class Base extends Method
         $cancelUrl =  $this->getNotificationURL($orderHash) . '&cancelled';
         $basketItems = BasketUtil::getBasketDetails($order);
         $basketAmount = BasketUtil::getBasketAmount($basketItems);
-        
+
         $currencyFactor = Frontend::getCurrency()->getConversionFactor();
         $convertedPrice = $order->fGesamtsumme * $currencyFactor;
         $totalAmount = (float)number_format($convertedPrice, 2, '.', '');
@@ -143,8 +143,27 @@ class Base extends Method
             $purpose = BasketUtil::createPurposeByBasket($basketItems);
         }
 
-        if (!$order->kBestellung) {
+        $orderNumber = '';
+        if (!$order->kBestellung) { // payment before order creation
+            try {
+                $orderHandler = new OrderHandler(
+                    Shop::Container()->getDB(),
+                    Frontend::getCustomer(),
+                    Frontend::getCart()
+                );
+                // It is available from version 5.2.0
+                if (method_exists($orderHandler, 'createOrderNo')) {
+                    $orderNumber = $orderHandler->createOrderNo();
+                }
+            } catch(Exception $e) {
+            }
             $successUrl = $this->getNotificationURL($orderHash) . '&payed';
+            if ($orderNumber) {
+                $successUrl .= '&orderNo=' . $orderNumber;
+                $order->cBestellNr = $orderNumber;
+            }
+        } else {
+           $successUrl = $this->getReturnURL($order);
         }
 
         $gateway = $payrexxApiService->createPayrexxGateway(
@@ -163,19 +182,22 @@ class Base extends Method
                 $this->orderService->setPaymentGatewayId(
                     $order->kBestellung,
                     $gateway->getId(),
-                    $orderHash,
+                    $order->cBestellNr ?? $orderHash,
                 );
             }
             $_SESSION['payrexxOrder'] = [
                 'gatewayId' => $gateway->getId(),
                 'orderHash' => $orderHash,
             ];
+            if ($orderNumber) {
+                $_SESSION['payrexxOrder']['orderNo'] = $orderNumber;
+            }
             $lang = $_SESSION['currentLanguage']->localizedName ?? 'en';
             $redirect = $gateway->getLink();
             $lang = strtolower(substr($lang, 0, 2));
             if (in_array($lang, ['en', 'de', 'it', 'fr', 'nl', 'pt', 'tr'])) {
                 $redirect = str_replace('?', $lang . '/?', $redirect);
-            }            
+            }
             \header('Location:' . $redirect);
             exit();
         }
@@ -193,17 +215,9 @@ class Base extends Method
     public function finalizeOrder(Bestellung $order, string $hash, array $args): bool
     {
         if (isset($args['payed'])) {
-            try {
-                $orderHandler = new OrderHandler(
-                    Shop::Container()->getDB(),
-                    Frontend::getCustomer(),
-                    Frontend::getCart()
-                );
-                // It is available from version 5.2.0
-                if (method_exists($orderHandler, 'createOrderNo')) {
-                    $order->cBestellNr = $orderHandler->createOrderNo();
-                }
-            } catch(Exception $e) {
+            $orderNumber = $args['orderNo'] ?? '';
+            if (!empty($orderNumber)) {
+                $order->cBestellNr = $orderNumber;
             }
             return true;
         }
@@ -239,14 +253,22 @@ class Base extends Method
             exit();
         }
 
+        $orderNumber = $args['orderNo'] ?? '';
         if (isset($args['sh']) &&
             isset($_SESSION['payrexxOrder']) &&
-            ($args['sh'] === $_SESSION['payrexxOrder']['orderHash'])
+            (
+                ($args['sh'] === $_SESSION['payrexxOrder']['orderHash']) ||
+                (
+                    !empty($orderNumber) &&
+                    isset($_SESSION['payrexxOrder']['orderNo']) &&
+                    $args['orderNo'] === $_SESSION['payrexxOrder']['orderNo']
+                )
+            )
         ) {
             $this->orderService->setPaymentGatewayId(
                 $order->kBestellung,
                 (int) $_SESSION['payrexxOrder']['gatewayId'],
-                $_SESSION['payrexxOrder']['orderHash']
+                $order->cBestellNr
             );
             $transaction = $this->payrexxApiService->getTransactionByGatewayId(
                 (int) $_SESSION['payrexxOrder']['gatewayId']

--- a/jtl_payrexx/src/Service/PayrexxApiService.php
+++ b/jtl_payrexx/src/Service/PayrexxApiService.php
@@ -82,7 +82,7 @@ class PayrexxApiService
         float $totalAmount,
         string $orderHash
     ) {
-        $referenceId = $order->kBestellung ?? $orderHash;
+        $referenceId = $order->cBestellNr ?? $orderHash;
 
         $payrexx = $this->getInterface();
         $gateway = new Gateway();

--- a/jtl_payrexx/src/Service/PayrexxApiService.php
+++ b/jtl_payrexx/src/Service/PayrexxApiService.php
@@ -68,6 +68,7 @@ class PayrexxApiService
      * @param array $basket
      * @param string $purpose
      * @param float $totalAmount
+     * @param string $orderHash
      * @return Gateway|null
      */
     public function createPayrexxGateway(
@@ -98,16 +99,16 @@ class PayrexxApiService
         $gateway->setReferenceId($referenceId);
         $gateway->setValidity(15);
 
-        $customer = $order->oKunde;
-        $street = $customer->cStrasse . ' ' . $customer->cHausnummer;
-        $gateway->addField('forename', $customer->cVorname);
-        $gateway->addField('surname', $customer->cNachname);
-        $gateway->addField('email', $customer->cMail);
-        $gateway->addField('company', $customer->cFirma);
+        $billingAddress = $order->oRechnungsadresse ?? $order->oKunde;
+        $street = $billingAddress->cStrasse . ' ' . $billingAddress->cHausnummer;
+        $gateway->addField('forename', $billingAddress->cVorname);
+        $gateway->addField('surname', $billingAddress->cNachname);
+        $gateway->addField('email', $billingAddress->cMail);
+        $gateway->addField('company', $billingAddress->cFirma);
         $gateway->addField('street', $street);
-        $gateway->addField('postcode', $customer->cPLZ);
-        $gateway->addField('place', $customer->cOrt);
-        $gateway->addField('country', $customer->cLand);
+        $gateway->addField('postcode', $billingAddress->cPLZ);
+        $gateway->addField('place', $billingAddress->cOrt);
+        $gateway->addField('country', $billingAddress->cLand);
         $gateway->addField('custom_field_1', $order->kBestellung, 'Shop order ID');
         $gateway->addField('custom_field_2', $order->cBestellNr, 'Shop Order Number');
 


### PR DESCRIPTION
Payment Before order creation.

1. The order number was used instead of the order ID as the reference ID.
2. Fixed billing address information.

