### PR TITLE
bugfix/PP-14072: Plugin JTL: Webhook Fails So That No Order Is Created

### DIFF
--- a/jtl_payrexx/Migrations/Migration20250130123045.php
+++ b/jtl_payrexx/Migrations/Migration20250130123045.php
@@ -5,7 +5,7 @@ namespace Plugin\jtl_payrexx\Migrations;
 use JTL\Plugin\Migration;
 use JTL\Update\IMigration;
 
-class Migration20241206094532 extends Migration implements IMigration
+class Migration20250130123045 extends Migration implements IMigration
 {
     public function up()
     {

--- a/jtl_payrexx/Migrations/Migration20250130123045.php
+++ b/jtl_payrexx/Migrations/Migration20250130123045.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Plugin\jtl_payrexx\Migrations;
+
+use JTL\Plugin\Migration;
+use JTL\Update\IMigration;
+
+class Migration20241206094532 extends Migration implements IMigration
+{
+    public function up()
+    {
+        $this->execute(
+            "ALTER TABLE
+                `plugin_jtl_payrexx_payments` CHANGE `order_id` `order_id` INT NULL;"
+        );
+    }
+
+    public function down()
+    {
+        $this->execute(
+            "ALTER TABLE
+                `plugin_jtl_payrexx_payments` CHANGE `order_id` `order_id` INT NOT NULL;"
+        );
+    }
+}

--- a/jtl_payrexx/composer.json
+++ b/jtl_payrexx/composer.json
@@ -4,7 +4,7 @@
     "description": "JTL-Shop 5 Plugin Container",
     "require": {
       "php": "^8.0",
-      "payrexx/payrexx": "^1.7.4"
+      "payrexx/payrexx": "^1.8"
     },
     "autoload": {
       "psr-4": {

--- a/jtl_payrexx/info.xml
+++ b/jtl_payrexx/info.xml
@@ -7,7 +7,7 @@
     <PluginID>jtl_payrexx</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.0.0</ShopVersion>
-    <Version>1.0.15</Version>
+    <Version>1.0.16</Version>
     <CreateDate>2024-04-15</CreateDate>
     <Install>
         <Adminmenu>

--- a/jtl_payrexx/paymentmethod/Base.php
+++ b/jtl_payrexx/paymentmethod/Base.php
@@ -176,13 +176,11 @@ class Base extends Method
             $orderHash
         );
         if ($gateway) {
-            if ($order->kBestellung) {
-                $this->orderService->setPaymentGatewayId(
-                    $order->kBestellung,
-                    $gateway->getId(),
-                    $order->cBestellNr ?? $orderHash,
-                );
-            }
+            $this->orderService->setPaymentGatewayId(
+                $order->kBestellung ?? null,
+                $gateway->getId(),
+                $order->cBestellNr ?? $orderHash,
+            );
             $_SESSION['payrexxOrder'] = [
                 'gatewayId' => $gateway->getId(),
                 'orderHash' => $orderHash,

--- a/jtl_payrexx/src/Service/OrderService.php
+++ b/jtl_payrexx/src/Service/OrderService.php
@@ -110,7 +110,6 @@ class OrderService
                 break;
         }
 
-        
         if (empty($orderNewStatus) || !$this->transitionAllowed($order->cStatus, $orderNewStatus)) {
             return;
         }
@@ -229,16 +228,22 @@ class OrderService
 
     /**
      * Get order info by order Id.
-     * 
+     *
      * @param string $referenceId
      * @return object
      */
     public function getOrderInfoByReference($referenceId)
     {
         $result = Shop::Container()->getDB()->queryPrepared(
-            'SELECT `gateway_id`, `order_id`
-                FROM `plugin_jtl_payrexx_payments`
-                WHERE (`order_id`  = :shopOrderId OR `order_hash` = :shopOrderId)',
+            'SELECT
+                `gateway_id`,
+                `order_id`
+            FROM
+                `plugin_jtl_payrexx_payments`
+            WHERE
+                (
+                    `order_id` = :shopOrderId OR `order_hash` = :shopOrderId
+                ) AND `order_id` IS NOT NULL',
             [
                 ':shopOrderId' => $referenceId,
             ],

--- a/jtl_payrexx/src/Service/OrderService.php
+++ b/jtl_payrexx/src/Service/OrderService.php
@@ -227,7 +227,7 @@ class OrderService
     }
 
     /**
-     * Get order info by order Id.
+     * Get order info by reference ID.
      *
      * @param string $referenceId
      * @return object

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -87,7 +87,7 @@ class Dispatcher
                 );
             } else {
                 $this->sendResponse('Webhook received before order creation,
-                 Order will be created on the success page.Order Number is ' . $referenceId
+                 Order will be created on the success page. Order Number is ' . $referenceId
                 );
             }
             $this->sendResponse('Webhook processed successfully!');

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -70,7 +70,7 @@ class Dispatcher
             if ($transaction->getStatus() !== $this->data['transaction']['status']) {
                 $this->sendResponse('Fraudulent transaction status');
             }
-            $order = new Bestellung((int) $referenceId);
+            $order = new Bestellung((int) $referenceId); // // Order Number or Order hash
             if (!$order->kBestellung) {
                 $result = $this->orderService->getOrderInfoByReference($referenceId);
                 if ($result) {
@@ -84,6 +84,10 @@ class Dispatcher
                     $transaction->getUuid(),
                     $transaction->getInvoice()['currencyAlpha3'],
                     (int) $transaction->getInvoice()['totalAmount']
+                );
+            } else {
+                $this->sendResponse('Webhook received before order creation,
+                    Order will create on success page. Order Number is ' . $referenceId
                 );
             }
             $this->sendResponse('Webhook processed successfully!');

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -70,7 +70,7 @@ class Dispatcher
             if ($transaction->getStatus() !== $this->data['transaction']['status']) {
                 $this->sendResponse('Fraudulent transaction status');
             }
-            $order = new Bestellung((int) $referenceId); // // Order Number or Order hash
+            $order = new Bestellung((int) $referenceId);
             if (!$order->kBestellung) {
                 $result = $this->orderService->getOrderInfoByReference($referenceId);
                 if ($result) {

--- a/jtl_payrexx/src/Webhook/Dispatcher.php
+++ b/jtl_payrexx/src/Webhook/Dispatcher.php
@@ -87,7 +87,7 @@ class Dispatcher
                 );
             } else {
                 $this->sendResponse('Webhook received before order creation,
-                    Order will create on success page. Order Number is ' . $referenceId
+                 Order will be created on the success page.Order Number is ' . $referenceId
                 );
             }
             $this->sendResponse('Webhook processed successfully!');


### PR DESCRIPTION
**Issue:**
After being redirected to the merchant website, the order and gateway ID are saved in the table.
Before redirecting to the merchant website, the webhook has been received.


**payment before order completion = yes** Saved the order number and gateway ID only to webhook validation.

And return the webhook response Like " Webhook received before order creation,  Order will be created on the success page. Order Number is 10012