### PR TITLE
bugfix/PP-14438: Plugin JTL: Show Correct Error Message On Payment Cancellation Or Denial

### DIFF
--- a/jtl_payrexx/info.xml
+++ b/jtl_payrexx/info.xml
@@ -7,7 +7,7 @@
     <PluginID>jtl_payrexx</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.0.0</ShopVersion>
-    <Version>1.0.17</Version>
+    <Version>1.0.18</Version>
     <CreateDate>2024-04-15</CreateDate>
     <Install>
         <Adminmenu>
@@ -659,9 +659,14 @@
                 <VariableLocalized iso="GER"><![CDATA[Klicken Sie zum Bestätigen]]></VariableLocalized>
             </Variable>
             <Variable>
-                <Name>jtl_payrexx_payment_cancelled</Name>
+                <Name>jtl_after_order_payrexx_payment_cancelled</Name>
                 <VariableLocalized iso="GER"><![CDATA[Ihre Bestellung wurde storniert. Bitte wählen Sie eine Zahlungsmethode, um eine neue Bestellung zu erstellen.]]></VariableLocalized>
                 <VariableLocalized iso="ENG"><![CDATA[Your order has been canceled. Please choose a payment method to create a new order.]]></VariableLocalized>
+            </Variable>
+            <Variable>
+                <Name>jtl_before_order_payrexx_payment_cancelled</Name>
+                <VariableLocalized iso="GER"><![CDATA[Ihre Zahlung wurde storniert. Bitte wählen Sie Ihre bevorzugte Zahlungsmethode, um fortzufahren.]]></VariableLocalized>
+                <VariableLocalized iso="ENG"><![CDATA[Your payment has been canceled. Please select your preferred payment method to continue.]]></VariableLocalized>
             </Variable>
         </Locales>
     </Install>

--- a/jtl_payrexx/paymentmethod/Base.php
+++ b/jtl_payrexx/paymentmethod/Base.php
@@ -303,7 +303,7 @@ class Base extends Method
      *
      * @param string $messageKey
      */
-    public function handleCancellation($messageKey): void
+    private function handleCancellation(string $messageKey): void
     {
         $langCode = $_SESSION['currentLanguage']->iso ?? 'eng';
         $errorMessage = $this->plugin->getLocalization()->getTranslation(

--- a/jtl_payrexx/paymentmethod/Base.php
+++ b/jtl_payrexx/paymentmethod/Base.php
@@ -217,6 +217,7 @@ class Base extends Method
             }
             return true;
         }
+        $this->handleCancellation('jtl_before_order_payrexx_payment_cancelled');
         return false;
     }
 
@@ -237,16 +238,7 @@ class Base extends Method
                 $order,
                 Transaction::CANCELLED
             );
-
-            $langCode = $_SESSION['currentLanguage']->localizedName ?? 'en';
-            $langText = 'jtl_payrexx_payment_cancelled';
-            $errorMessage = $this->plugin->getLocalization()->getTranslation($langText, $langCode);;
-            $errorMessage = $errorMessage ?? 'Your order has been canceled. Please choose a payment method to create a new order.';
-            $alertHelper = Shop::Container()->getAlertService();
-            $alertHelper->addAlert(Alert::TYPE_ERROR, $errorMessage, md5($errorMessage), ['saveInSession' => true]);
-            $linkHelper = Shop::Container()->getLinkService();
-            \header('Location: ' . $linkHelper->getStaticRoute('bestellvorgang.php') . '?editZahlungsart=1');
-            exit();
+            $this->handleCancellation('jtl_after_order_payrexx_payment_cancelled');
         }
 
         $orderNumber = $args['orderNo'] ?? '';
@@ -304,5 +296,32 @@ class Base extends Method
     public function canPayAgain(): bool
     {
         return false;
+    }
+
+    /**
+     * Handle payment cancellation
+     *
+     * @param string $messageKey
+     */
+    public function handleCancellation($messageKey): void
+    {
+        $langCode = $_SESSION['currentLanguage']->iso ?? 'eng';
+        $errorMessage = $this->plugin->getLocalization()->getTranslation(
+            $messageKey,
+            $langCode
+        ) ?? '';
+        if (!empty($errorMessage)) {
+            $alertHelper = Shop::Container()->getAlertService();
+            $alertHelper->addAlert(
+                Alert::TYPE_ERROR,
+                $errorMessage,
+                md5($errorMessage),
+                ['saveInSession' => true]
+            );
+        }
+
+        $linkHelper = Shop::Container()->getLinkService();
+        \header('Location: ' . $linkHelper->getStaticRoute('bestellvorgang.php') . '?editZahlungsart=1');
+        exit();
     }
 }


### PR DESCRIPTION
 Implemented a new error message to the payment before order for payment cancellation.