### PR TITLE
task/PP-16949: Add Payment Method VERD.cash in JTL

### DIFF
--- a/jtl_payrexx/info.xml
+++ b/jtl_payrexx/info.xml
@@ -7,7 +7,7 @@
     <PluginID>jtl_payrexx</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.2.3</ShopVersion>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <CreateDate>2024-04-15</CreateDate>
     <Install>
         <JS>
@@ -706,6 +706,30 @@
                 </MethodLanguage>
                 <MethodLanguage iso="ENG">
                     <Name>Crypto</Name>
+                    <ChargeName>Payrexx Payment Method</ChargeName>
+                    <InfoText></InfoText>
+                </MethodLanguage>
+            </Method>
+            <Method>
+                <Name>VERD.cash</Name>
+                <Sort>28</Sort>
+                <SendMail>1</SendMail>
+                <Provider>Payrexx</Provider>
+                <TSCode>OTHER</TSCode>
+                <PreOrder>0</PreOrder>
+                <Soap>0</Soap>
+                <Curl>0</Curl>
+                <Sockets>0</Sockets>
+                <ClassFile>VerdCash.php</ClassFile>
+                <ClassName>VerdCash</ClassName>
+                <TemplateFile>template/payrexx_payment.tpl</TemplateFile>
+                <MethodLanguage iso="GER">
+                    <Name>VERD.cash</Name>
+                    <ChargeName>Payrexx Payment Method</ChargeName>
+                    <InfoText></InfoText>
+                </MethodLanguage>
+                <MethodLanguage iso="ENG">
+                    <Name>VERD.cash</Name>
                     <ChargeName>Payrexx Payment Method</ChargeName>
                     <InfoText></InfoText>
                 </MethodLanguage>

--- a/jtl_payrexx/paymentmethod/VerdCash.php
+++ b/jtl_payrexx/paymentmethod/VerdCash.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plugin\jtl_payrexx\paymentmethod;
+
+/**
+ * Class VerdCash
+ * @package Plugin\jtl_payrexx\paymentmethod
+ */
+class VerdCash extends Base
+{
+    public function __construct(string $moduleID)
+    {
+        parent::__construct($moduleID, 'verd-cash');
+    }
+}


### PR DESCRIPTION
- Added new payment method VERD.cash
- Showing the payment method on checkout.
- After clicking, redirect to the payrexx payment page.